### PR TITLE
feat(adminv2): #CAV2-372, add application type to filter application list for ADML

### DIFF
--- a/deployment/lystore/conf.json.template
+++ b/deployment/lystore/conf.json.template
@@ -6,6 +6,7 @@
         "app-name" : "Lystore",
     	"app-address" : "/lystore",
     	"app-icon" : "${host}/lystore/public/img/logo.png",
+        "app-type" : "END_USER",
         "host": "${host}",
         "ssl" : $ssl,
         "auto-redeploy": false,


### PR DESCRIPTION
Dans la console v2, nous avons une évolution qui permet d'afficher les applications administrables à un ADML en filtrant par type. Nous avons besoin d'ajouter pour toutes les applications un attribute app-type dans la configuration de l'application. Cette évolution sera visible à partir de la version 3.5 d'entcore. En attendant, la modification de la config n'aura pas d'impact. Vous pouvez revenir vers moi pour toute question ou commentaire.