### PR TITLE
fix(infra-front 3.12): Fix material font path into module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ src/main/resources/public/dist
 src/main/resources/public/temp
 src/main/resources/public/js
 src/main/resources/public/fonts
+src/main/resources/public/font
 src/main/resources/public/template/entcore
 src/main/resources/view/
 rev-manifest.json

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ gulp.task('webpack', ['copy-mdi-font'], () => {
 
 gulp.task('copy-mdi-font', ['copy-files'], function () {
     return gulp.src('./node_modules/@mdi/font/fonts/*')
-        .pipe(gulp.dest('./presences/src/main/resources/public/font/material-design/fonts'));
+        .pipe(gulp.dest('./src/main/resources/public/font/material-design/fonts'));
 });
 
 


### PR DESCRIPTION
Le chemin material dans la compilation gulpfile n'était pas positionné dans le bon module du coup le code scss 
https://github.com/OPEN-ENT-NG/lystore/blob/master/src/main/resources/public/sass/global/_lystore-specifics.scss#L2 n'était pas bon