### PR TITLE
fix(infra-front 3.12): MLYSTOR-514 use auto $digest on tabs switch

### DIFF
--- a/src/main/resources/public/ts/directives/tabs.ts
+++ b/src/main/resources/public/ts/directives/tabs.ts
@@ -1,6 +1,6 @@
 import {ng, idiom as lang} from 'entcore';
 
-export const Tabs = ng.directive('tabs', () => {
+export const Tabs = ng.directive('tabs', ($timeout) => {
     return {
         restrict: 'E',
         scope: {
@@ -10,20 +10,18 @@ export const Tabs = ng.directive('tabs', () => {
         },
         template: `
         <div class="tabs-container row">
-            <div ng-repeat="menu  in menus" class="menu aligned" ng-class="{'selected': ngModel == menu.value}" ng-click="selectMenu(menu)">
+            <div ng-repeat="menu in menus" class="menu aligned" ng-class="{'selected': ngModel == menu.value}" ng-click="selectMenu(menu)">
                 [[lang.translate(menu.name)]]
             </div>
         </div>
         `,
         link: function ($scope, $element, $attrs, ngModel) {
             $scope.lang = lang;
-            $scope.selectMenu =(menu)=>{
+            $scope.selectMenu = (menu) => {
                 let oldModel = $scope.ngModel;
                 $scope.ngModel = menu.value;
-                if(oldModel != $scope.ngModel && $scope.ngChange){
-                    $scope.$apply();
-                    $scope.ngChange();
-
+                if (oldModel != $scope.ngModel && $scope.ngChange) {
+                    $timeout($scope.ngChange);
                 }
             }
         }


### PR DESCRIPTION
Le problème étant que l'apply est maintenant appliqué avant de procéder au ngChange (la conséquence est que le $scope parent qui applique une méthode dans le ngChange ne verra pas la donnée se mettre à jour correctement)

On résout le problème en appliquant un $timeout qui va appliquer ($apply) la fonction dans un `$scope.$apply()` qui va provoquer systématiquement le déclenchement du cycle $digest 
(voir doc https://docs.angularjs.org/api/ng/service/$timeout le 3eme param qui l'applique par défaut)