### PR TITLE
fix(gulp): re-add gulp task to add material design fonts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,13 @@ gulp.task('drop-cache', function(){
         .pipe(clean());
 });
 
-gulp.task('webpack', ['drop-cache'], () => {
+
+gulp.task('copy-mdi-font', ['drop-cache'], function () {
+    return gulp.src('./node_modules/@mdi/font/fonts/*')
+        .pipe(gulp.dest('./src/main/resources/public/font/material-design/fonts'));
+});
+
+gulp.task('webpack', ['copy-mdi-font'], () => {
     return gulp.src('./src/main/resources/public')
         .pipe(webpack(require('./webpack.config.js')))
         .on('error', function handleError() {


### PR DESCRIPTION
## Describe your changes

Fix la PR #87 

la tâche gulp du côté front qui consistait à rajouter les fonts du material-design avait été enlevé => c'est remis avec le même chemin que le scss est censé utilisé : https://github.com/opendigitaleducation/entcore-css-lib/blob/master/scss/specifics/lystore/_lystore.scss#L3

## Checklist tests

Sans css = se connecter en tant qu'admin sur {host} et aller sur {{host}}/lystore/parameter#/parameter

On voit les endpoints envoient une 404 :  
- ${host}/lystore/public/font/material-design/fonts/materialdesignicons-webfont.woff2
- ${host}/lystore/public/font/material-design/fonts/materialdesignicons-webfont.ttf

Avec css = se connecter en tant qu'admin sur {host} et aller sur {{host}}/lystore/parameter#/parameter
On voit les endpoints envoient une 200 (se télécharge)  

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

